### PR TITLE
Update jquery.jqprint-0.3.js

### DIFF
--- a/jquery.jqprint-0.3.js
+++ b/jquery.jqprint-0.3.js
@@ -18,23 +18,23 @@
         opt = $.extend({}, $.fn.jqprint.defaults, options);
 
         var $element = (this instanceof jQuery) ? this : $(this);
-        
-        if (opt.operaSupport && $.browser.opera) 
-        { 
-            var tab = window.open("","jqPrint-preview");
-            tab.document.open();
+   //$.browser not supported as of jQuery1.9     
+   //     if (opt.operaSupport && $.browser.opera) 
+   //     { 
+   //         var tab = window.open("","jqPrint-preview");
+   //         tab.document.open();
 
-            var doc = tab.document;
-        }
-        else 
-        {
+   //         var doc = tab.document;
+   //     }
+   //     else 
+   //     {
             var $iframe = $("<iframe  />");
         
             if (!opt.debug) { $iframe.css({ position: "absolute", width: "0px", height: "0px", left: "-600px", top: "-600px" }); }
 
             $iframe.appendTo("body");
             var doc = $iframe[0].contentWindow.document;
-        }
+    //    }
         
         if (opt.importCSS)
         {
@@ -56,9 +56,13 @@
         else { $element.each( function() { doc.write($(this).html()); }); }
         
         doc.close();
-        
-        (opt.operaSupport && $.browser.opera ? tab : $iframe[0].contentWindow).focus();
-        setTimeout( function() { (opt.operaSupport && $.browser.opera ? tab : $iframe[0].contentWindow).print(); if (tab) { tab.close(); } }, 1000);
+ 
+        //(opt.operaSupport && $.browser.opera ? tab : $iframe[0].contentWindow).focus();
+        ($iframe[0].contentWindow).focus();
+
+        //setTimeout( function() { (opt.operaSupport && $.browser.opera ? tab : $iframe[0].contentWindow).print(); if (tab) { tab.close(); } }, 1000);
+        setTimeout( function() { ($iframe[0].contentWindow).print();  }, 1000);
+
     }
     
     $.fn.jqprint.defaults = {


### PR DESCRIPTION
$.browser is no longer supported in jQuery 1.9
Commented out lines with $browser, disabled Opera related stuff.
Tested, works with jQuery 1.9
