### PR TITLE
Allow both <link> and <style> tags for CSS import

### DIFF
--- a/jquery.jqprint-0.3.js
+++ b/jquery.jqprint-0.3.js
@@ -35,19 +35,19 @@
             $iframe.appendTo("body");
             var doc = $iframe[0].contentWindow.document;
         }
-        
+
         if (opt.importCSS)
         {
-            if ($("link[media=print]").length > 0) 
-            {
-                $("link[media=print]").each( function() {
-                    doc.write("<link type='text/css' rel='stylesheet' href='" + $(this).attr("href") + "' media='print' />");
+            var $head = $('head', doc);
+            var printStyles = $('style[media="print"], link[media="print"]');
+            if(printStyles.length > 0) {
+                $(printStyles).each(function() {
+                    doc.write($('<div></div>').html($(this).clone()).html());
                 });
             }
-            else 
-            {
-                $("link").each( function() {
-                    doc.write("<link type='text/css' rel='stylesheet' href='" + $(this).attr("href") + "' />");
+            else {
+                $('link, style').each(function() {
+                    doc.write($('<div></div>').html($(this).clone()).html());
                 });
             }
         }

--- a/jquery.jqprint-0.3.js
+++ b/jquery.jqprint-0.3.js
@@ -38,7 +38,6 @@
 
         if (opt.importCSS)
         {
-            var $head = $('head', doc);
             var printStyles = $('style[media="print"], link[media="print"]');
             if(printStyles.length > 0) {
                 $(printStyles).each(function() {


### PR DESCRIPTION
Hey there, 
Thanks for putting this together.  I noticed that any CSS specified in style tags is ignored by this plugin.  This pull request allows the use of style tags, as well as simplifying the process by simply cloning over the existing tag.  Hope you'll consider it!
